### PR TITLE
stop tracking .env and rely on .env.example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+#Environment variables
+.env
+.env.*


### PR DESCRIPTION
This PR removes the tracked `.env` file and uses `.env.example`
as the reference for environment configuration.

Changes:
- Added .env to .gitignore
- Removed .env from git tracking
- Kept .env.example as the reference 