### PR TITLE
Add basic Material theme configuration for Flutter app

### DIFF
--- a/mobile_app/lib/app.dart
+++ b/mobile_app/lib/app.dart
@@ -4,6 +4,7 @@ import 'features/patients/patients_screen.dart';
 import 'features/medications/medications_screen.dart';
 import 'features/schedules/schedules_screen.dart';
 import 'features/reminders/reminders_screen.dart';
+import 'theme/app_theme.dart';
 
 class MedTrackApp extends StatelessWidget {
   const MedTrackApp({super.key});
@@ -12,7 +13,7 @@ class MedTrackApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'MedTrack OSS',
-      theme: ThemeData(primarySwatch: Colors.blue, useMaterial3: true),
+      theme: AppTheme.lightTheme,
       initialRoute: '/',
       routes: {
         '/': (context) => const HomeScreen(),

--- a/mobile_app/lib/theme/app_theme.dart
+++ b/mobile_app/lib/theme/app_theme.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static ThemeData lightTheme = ThemeData(
+    useMaterial3: true,
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: Colors.blue,
+      brightness: Brightness.light,
+    ),
+    appBarTheme: const AppBarTheme(
+      centerTitle: true,
+      elevation: 0,
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+        padding: const EdgeInsets.symmetric(vertical: 14),
+      ),
+    ),
+  );
+}

--- a/mobile_app/pubspec.lock
+++ b/mobile_app/pubspec.lock
@@ -143,10 +143,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -204,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/mobile_app/test/widget_test.dart
+++ b/mobile_app/test/widget_test.dart
@@ -8,7 +8,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:mobile_app/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {


### PR DESCRIPTION
What I changed:
- Added centralized Material 3 theme configuration
- Replaced inline ThemeData with reusable AppTheme

Why this change:
- Improves visual consistency across the Flutter app
- Makes theming scalable and easier to maintain

Fixes #6
<img width="1576" height="884" alt="Screenshot 2026-02-04 195353" src="https://github.com/user-attachments/assets/28cd706b-ed0a-411b-85e4-f38f8559c6d9" />
