### PR TITLE
fix: Back Button not working

### DIFF
--- a/mobile_app/lib/features/home/home_screen.dart
+++ b/mobile_app/lib/features/home/home_screen.dart
@@ -49,28 +49,28 @@ class HomeScreen extends StatelessWidget {
               children: [
                 IconButton(
                   onPressed: () {
-                    Navigator.pushReplacementNamed(context, '/patients');
+                    Navigator.pushNamedAndRemoveUntil(context, '/patients', (route) => route.isFirst);
                   },
                   icon: const Icon(Icons.people),
                   tooltip: 'View Patients',
                 ),
                 IconButton(
                   onPressed: () {
-                    Navigator.pushReplacementNamed(context, '/medications');
+                    Navigator.pushNamedAndRemoveUntil(context, '/medications', (route) => route.isFirst);
                   },
                   icon: const Icon(Icons.medication_liquid),
                   tooltip: 'View Medications',
                 ),
                 IconButton(
                   onPressed: () {
-                    Navigator.pushReplacementNamed(context, '/schedules');
+                    Navigator.pushNamedAndRemoveUntil(context, '/schedules', (route) => route.isFirst);
                   },
                   icon: const Icon(Icons.schedule),
                   tooltip: 'View Schedules',
                 ),
                 IconButton(
                   onPressed: () {
-                    Navigator.pushReplacementNamed(context, '/reminders');
+                    Navigator.pushNamedAndRemoveUntil(context, '/reminders', (route) => route.isFirst);
                   },
                   icon: const Icon(Icons.alarm),
                   tooltip: 'View Reminders',


### PR DESCRIPTION
the issue was happening becuase i used `pushReplaceNamed` instead of `pushNamed` the reason was pushReplaceNamed removes the route to the previous page, which hides the back button

<img width="144" height="320" alt="image" src="https://github.com/user-attachments/assets/44dfa6df-d1c4-4dd2-a096-830ffb941e64" />
<img width="144" height="320" alt="image" src="https://github.com/user-attachments/assets/093f0a22-ab00-4ab6-9bf9-91debf351ac4" />
<img width="144" height="320" alt="image" src="https://github.com/user-attachments/assets/39bfb07c-5980-403b-834f-faf5c68f6c28" />
<img width="144" height="320" alt="image" src="https://github.com/user-attachments/assets/a5a11a21-7a31-4b02-b369-3b026eb188f9" />


Fixed #15