### PR TITLE
fix(patients): add AppBar back button on patient profile screen

### DIFF
--- a/mobile_app/lib/features/patients/widgets/patient_details_view.dart
+++ b/mobile_app/lib/features/patients/widgets/patient_details_view.dart
@@ -13,7 +13,11 @@ class PatientDetailsView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        automaticallyImplyLeading: false,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).maybePop(),
+          tooltip: 'Back',
+        ),
         title: const Text('Patient Profile'),
         actions: [
           IconButton(onPressed: () {}, icon: const Icon(Icons.edit)),


### PR DESCRIPTION
## Summary
- Adds a visible in-app back arrow on the Patient Profile screen AppBar.
- Back button uses `Navigator.maybePop()` to return to the Patients list.
- Removes reliance on system back gesture/button for this flow.

## Problem
Patient Profile did not show a back button in the AppBar, making return navigation less discoverable.

## Solution
Replaced disabled implied leading behavior with an explicit AppBar leading `IconButton` (back arrow).

## Test Plan
- Open the app.
- Go to **Patients**.
- Open any patient card.
- Verify **Patient Profile** shows a back arrow in the AppBar.
- Tap the back arrow and confirm it returns to the **Patients** list.