### PR TITLE
fixes #2   Centralized the Homescreen Navbar

### DIFF
--- a/mobile_app/lib/features/home/home_screen.dart
+++ b/mobile_app/lib/features/home/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_app/routes.dart';
+import 'package:mobile_app/navigation/widgets/main_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -10,36 +11,6 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  int _selectedIndex = 0;
-
-  final List<_NavItem> _navItems = [
-    _NavItem(
-      icon: Icons.home_rounded,
-      label: 'Home',
-      route: Routes.home,
-    ),
-    _NavItem(
-      icon: Icons.people_rounded,
-      label: 'Patients',
-      route: Routes.patients,
-    ),
-    _NavItem(
-      icon: Icons.medication_rounded,
-      label: 'Medications',
-      route: Routes.medications,
-    ),
-    _NavItem(
-      icon: Icons.schedule_rounded,
-      label: 'Schedules',
-      route: Routes.schedules,
-    ),
-    _NavItem(
-      icon: Icons.notifications_rounded,
-      label: 'Reminders',
-      route: Routes.reminders,
-    ),
-  ];
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -143,7 +114,13 @@ class _HomeScreenState extends State<HomeScreen> {
                     description: 'View and manage',
                     color: const Color(0xFF0066CC),
                     onTap: () {
-                      Navigator.pushNamed(context, Routes.patients);
+                      final mainState =
+                          context.findAncestorStateOfType<MainScreenState>();
+                      if (mainState != null) {
+                        mainState.switchTab(1);
+                      } else {
+                        Navigator.pushNamed(context, Routes.patients);
+                      }
                     },
                   ),
                   _ActionCard(
@@ -152,7 +129,13 @@ class _HomeScreenState extends State<HomeScreen> {
                     description: 'Track prescribed',
                     color: const Color(0xFF00B4D8),
                     onTap: () {
-                      Navigator.pushNamed(context, Routes.medications);
+                      final mainState =
+                          context.findAncestorStateOfType<MainScreenState>();
+                      if (mainState != null) {
+                        mainState.switchTab(2);
+                      } else {
+                        Navigator.pushNamed(context, Routes.medications);
+                      }
                     },
                   ),
                   _ActionCard(
@@ -161,7 +144,13 @@ class _HomeScreenState extends State<HomeScreen> {
                     description: 'Monitor timings',
                     color: const Color(0xFFFF6B6B),
                     onTap: () {
-                      Navigator.pushNamed(context, Routes.schedules);
+                      final mainState =
+                          context.findAncestorStateOfType<MainScreenState>();
+                      if (mainState != null) {
+                        mainState.switchTab(3);
+                      } else {
+                        Navigator.pushNamed(context, Routes.schedules);
+                      }
                     },
                   ),
                   _ActionCard(
@@ -171,7 +160,8 @@ class _HomeScreenState extends State<HomeScreen> {
                     color: const Color(0xFF4CAF50),
                     onTap: () {
                       ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('Adherence feature coming soon!')),
+                        const SnackBar(
+                            content: Text('Adherence feature coming soon!')),
                       );
                     },
                   ),
@@ -265,61 +255,8 @@ class _HomeScreenState extends State<HomeScreen> {
           ),
         ),
       ),
-      bottomNavigationBar: Container(
-        decoration: BoxDecoration(color: Colors.blue.shade100),
-        child: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8.0),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                IconButton(
-                  onPressed: () {
-                    Navigator.pushNamedAndRemoveUntil(context, Routes.patients, (route) => route.isFirst);
-                  },
-                  icon: const Icon(Icons.people),
-                  tooltip: 'View Patients',
-                ),
-                IconButton(
-                  onPressed: () {
-                    Navigator.pushNamedAndRemoveUntil(context, Routes.medications, (route) => route.isFirst);
-                  },
-                  icon: const Icon(Icons.medication_liquid),
-                  tooltip: 'View Medications',
-                ),
-                IconButton(
-                  onPressed: () {
-                    Navigator.pushNamedAndRemoveUntil(context, Routes.schedules, (route) => route.isFirst);
-                  },
-                  icon: const Icon(Icons.schedule),
-                  tooltip: 'View Schedules',
-                ),
-                IconButton(
-                  onPressed: () {
-                    Navigator.pushNamedAndRemoveUntil(context, Routes.reminders, (route) => route.isFirst);
-                  },
-                  icon: const Icon(Icons.alarm),
-                  tooltip: 'View Reminders',
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
     );
   }
-}
-
-class _NavItem {
-  final IconData icon;
-  final String label;
-  final String route;
-
-  _NavItem({
-    required this.icon,
-    required this.label,
-    required this.route,
-  });
 }
 
 class _ActionCard extends StatelessWidget {

--- a/mobile_app/lib/features/patients/widgets/add_patient_note_view.dart
+++ b/mobile_app/lib/features/patients/widgets/add_patient_note_view.dart
@@ -44,13 +44,14 @@ class _AddPatientNoteViewState extends State<AddPatientNoteView> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-               _buildPatientInfoCard(context),
+              _buildPatientInfoCard(context),
               const SizedBox(height: 24),
               DropdownButtonFormField<String>(
-                value: _selectedCategory,
+                initialValue: _selectedCategory,
                 decoration: InputDecoration(
                   labelText: 'Category',
-                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                  border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12)),
                   prefixIcon: const Icon(Icons.label),
                 ),
                 items: _categories.map((String category) {
@@ -72,7 +73,8 @@ class _AddPatientNoteViewState extends State<AddPatientNoteView> {
                 controller: _titleController,
                 decoration: InputDecoration(
                   labelText: 'Title',
-                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                  border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12)),
                   prefixIcon: const Icon(Icons.title),
                 ),
                 validator: (value) {
@@ -87,7 +89,8 @@ class _AddPatientNoteViewState extends State<AddPatientNoteView> {
                 controller: _noteController,
                 decoration: InputDecoration(
                   labelText: 'Content',
-                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                  border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12)),
                   prefixIcon: const Icon(Icons.description),
                   alignLabelWithHint: true,
                 ),

--- a/mobile_app/lib/features/reminders/add_reminder_screen.dart
+++ b/mobile_app/lib/features/reminders/add_reminder_screen.dart
@@ -1,8 +1,6 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import '../../models/reminder.dart';
-import '../../routes.dart';
 
 class AddReminderScreen extends StatefulWidget {
   const AddReminderScreen({super.key});
@@ -17,8 +15,8 @@ class _AddReminderScreenState extends State<AddReminderScreen> {
   String _medicationName = '';
   String _patientName = '';
   TimeOfDay _scheduledTime = TimeOfDay.now();
-  List<String> _type = ['Morning', 'Afternoon', 'Evening', 'Weekly'];
-  bool _isEnabled = true;
+  final List<String> _type = ['Morning', 'Afternoon', 'Evening', 'Weekly'];
+  final bool _isEnabled = true;
   int _notificationCount = 1;
   int id = 5;
   String? _selectedType;
@@ -122,7 +120,7 @@ class _AddReminderScreenState extends State<AddReminderScreen> {
                           }
                           return null;
                         },
-                        value: _selectedType,
+                        initialValue: _selectedType,
                         hint: const Text("Type"),
                         decoration: InputDecoration(
                           enabledBorder: OutlineInputBorder(
@@ -165,7 +163,7 @@ class _AddReminderScreenState extends State<AddReminderScreen> {
                             _selectedType = value as String;
                           });
                         },
-                        onSaved: (value) => _selectedType = value as String?,
+                        onSaved: (value) => _selectedType = value,
                       ),
                       SizedBox(height: 15),
                       Card(
@@ -185,7 +183,7 @@ class _AddReminderScreenState extends State<AddReminderScreen> {
                               color: Colors.blue,
                             ),
                             subtitle: Text(
-                              "${_scheduledTime.format(context)}",
+                              _scheduledTime.format(context),
                               style: TextStyle(
                                   color: Colors.black,
                                   fontSize: 18,
@@ -228,7 +226,7 @@ class _AddReminderScreenState extends State<AddReminderScreen> {
                           leading: Icon(Icons.notification_add),
                           iconColor: Colors.blue,
                           subtitle: Text(
-                              "${_notificationCount} ${_notificationCount == 1 ? 'notification' : 'notifications'} before"),
+                              "$_notificationCount ${_notificationCount == 1 ? 'notification' : 'notifications'} before"),
                           trailing: Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [
@@ -243,16 +241,17 @@ class _AddReminderScreenState extends State<AddReminderScreen> {
                                 icon: Icon(Icons.remove),
                               ),
                               Text(
-                                "${_notificationCount}",
+                                "$_notificationCount",
                                 style: TextStyle(
                                     fontSize: 14, fontWeight: FontWeight.bold),
                               ),
                               IconButton(
                                 onPressed: () {
-                                  if (_notificationCount < 5)
+                                  if (_notificationCount < 5) {
                                     setState(() {
                                       _notificationCount++;
                                     });
+                                  }
                                 },
                                 icon: Icon(Icons.add),
                               ),

--- a/mobile_app/lib/features/reminders/reminders_screen.dart
+++ b/mobile_app/lib/features/reminders/reminders_screen.dart
@@ -246,7 +246,7 @@ class _ReminderCardState extends State<_ReminderCard> {
                         ),
                       );
                     },
-                    activeColor: typeColor,
+                    activeThumbColor: typeColor,
                   ),
                 ),
               ],

--- a/mobile_app/lib/features/schedules/schedule_appointment_view.dart
+++ b/mobile_app/lib/features/schedules/schedule_appointment_view.dart
@@ -8,7 +8,8 @@ class ScheduleAppointmentView extends StatefulWidget {
   const ScheduleAppointmentView({super.key, required this.patient});
 
   @override
-  State<ScheduleAppointmentView> createState() => _ScheduleAppointmentViewState();
+  State<ScheduleAppointmentView> createState() =>
+      _ScheduleAppointmentViewState();
 }
 
 class _ScheduleAppointmentViewState extends State<ScheduleAppointmentView> {
@@ -170,7 +171,7 @@ class _ScheduleAppointmentViewState extends State<ScheduleAppointmentView> {
 
   Widget _buildTypeDropdown(BuildContext context) {
     return DropdownButtonFormField<String>(
-      value: _selectedType,
+      initialValue: _selectedType,
       decoration: InputDecoration(
         labelText: 'Type',
         border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
@@ -213,7 +214,7 @@ class _ScheduleAppointmentViewState extends State<ScheduleAppointmentView> {
         );
         return;
       }
-      
+
       // Here you would typically save the appointment to a database
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Appointment Scheduled Successfully')),

--- a/mobile_app/lib/models/reminder.dart
+++ b/mobile_app/lib/models/reminder.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/material.dart';
-
 class Reminder {
   final int id;
   final String medication;

--- a/mobile_app/lib/navigation/widgets/main_screen.dart
+++ b/mobile_app/lib/navigation/widgets/main_screen.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_app/features/home/home_screen.dart';
+import 'package:mobile_app/features/medications/medications_screen.dart';
+import 'package:mobile_app/features/patients/patients_screen.dart';
+import 'package:mobile_app/features/reminders/reminders_screen.dart';
+import 'package:mobile_app/features/schedules/schedules_screen.dart';
+
+class MainScreen extends StatefulWidget {
+  const MainScreen({super.key});
+  static const String route = '/main';
+
+  @override
+  State<MainScreen> createState() => MainScreenState();
+}
+
+class MainScreenState extends State<MainScreen> {
+  int _selectedIndex = 0;
+
+  final List<Widget> _screens = const [
+    HomeScreen(),
+    PatientsScreen(),
+    MedicationsScreen(),
+    SchedulesScreen(),
+    RemindersScreen(),
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  // Allow children to switch tabs if needed (e.g., from Home dashboard)
+  void switchTab(int index) {
+    if (index >= 0 && index < _screens.length) {
+      setState(() {
+        _selectedIndex = index;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _selectedIndex,
+        children: _screens,
+      ),
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 10,
+              offset: const Offset(0, -5),
+            ),
+          ],
+        ),
+        child: NavigationBar(
+          selectedIndex: _selectedIndex,
+          onDestinationSelected: _onItemTapped,
+          backgroundColor: Colors.white,
+          elevation: 0,
+          destinations: const [
+            NavigationDestination(
+              icon: Icon(Icons.home_outlined),
+              selectedIcon: Icon(Icons.home_rounded),
+              label: 'Home',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.people_outlined),
+              selectedIcon: Icon(Icons.people_rounded),
+              label: 'Patients',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.medication_outlined),
+              selectedIcon: Icon(Icons.medication_rounded),
+              label: 'Meds',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.calendar_today_outlined),
+              selectedIcon: Icon(Icons.calendar_today_rounded),
+              label: 'Schedule',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.notifications_outlined),
+              selectedIcon: Icon(Icons.notifications_rounded),
+              label: 'Reminders',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/routes.dart
+++ b/mobile_app/lib/routes.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mobile_app/navigation/widgets/main_screen.dart';
 import 'package:mobile_app/features/home/home_screen.dart';
 import 'package:mobile_app/features/medications/add_medication_screen.dart';
 import 'package:mobile_app/features/medications/medications_screen.dart';
@@ -27,7 +28,7 @@ class Routes {
 
 Map<String, WidgetBuilder> getRoutes() {
   return {
-    Routes.home: (context) => const HomeScreen(),
+    Routes.home: (context) => const MainScreen(),
     Routes.patients: (context) => const PatientsScreen(),
     Routes.medications: (context) => const MedicationsScreen(),
     Routes.addMedication: (context) => const AddMedicationScreen(),


### PR DESCRIPTION
This PR refactors the application's navigation architecture by introducing a persistent MainScreen shell. This ensures the Bottom Navigation Bar remains visible across primary tabs (Home, Patients, Medications, etc.) and preserves the state of each tab when switching.

🔑 Key Changes
New MainScreen: Created a shell widget in lib/navigation/widgets/main_screen.dart that uses IndexedStack to manage multiple top-level screens without rebuilding them. 
Updated HomeScreen: Removed the local BottomNavigationBar from home_screen.dart. The "Quick Actions" grid now switches tabs on the parent MainScreen instead of pushing new routes. 
Routing Update: Updated Routes.home in routes.dart to point to MainScreen as the initial route.

<img width="476" height="1004" alt="image" src="https://github.com/user-attachments/assets/ecc645ad-3c3d-4876-9074-094f61a26fae" />
<img width="482" height="1006" alt="image" src="https://github.com/user-attachments/assets/8e117f83-6ddb-42db-abb6-e0dab3145424" />
<img width="483" height="1017" alt="image" src="https://github.com/user-attachments/assets/e37a2917-0bf5-497e-b259-3e833084bc5f" />
<img width="486" height="1029" alt="image" src="https://github.com/user-attachments/assets/217db8c5-9d8f-44f1-8f56-c983d07e0788" />
<img width="497" height="1026" alt="image" src="https://github.com/user-attachments/assets/fa480268-410d-496f-8664-2da03f595e41" />
