### PR TITLE
feat: wire up Add Patient screen and fix navigation

### DIFF
--- a/mobile_app/lib/features/patients/professional_patients_screen.dart
+++ b/mobile_app/lib/features/patients/professional_patients_screen.dart
@@ -62,7 +62,7 @@ class _ProfessionalPatientsScreenState extends State<ProfessionalPatientsScreen>
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          // TODO: Navigate to Add Patient screen
+          Navigator.pushNamed(context, Routes.addPatient);
         },
         child: const Icon(Icons.add),
       ),

--- a/mobile_app/lib/routes.dart
+++ b/mobile_app/lib/routes.dart
@@ -35,5 +35,6 @@ Map<String, WidgetBuilder> getRoutes() {
     Routes.schedules: (context) => const SchedulesScreen(),
     Routes.reminders: (context) => const RemindersScreen(),
     Routes.addReminder: (context) => const AddReminderScreen(),
+    Routes.addPatient: (context) => const AddPatientScreen(),
   };
 }


### PR DESCRIPTION
The AddPatientScreen is implemented in lib/features/patients/add_patient_screen.dart but is currently unreachable.

The route Routes.addPatient is defined but missing from the getRoutes() map in lib/routes.dart.
The FloatingActionButton in ProfessionalPatientsScreen has a TODO and needs to be connected to navigate to this route.